### PR TITLE
Climbing PR

### DIFF
--- a/cb_calculator.html
+++ b/cb_calculator.html
@@ -39,6 +39,12 @@
                     <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
                     </div>
                     <div class="modal-body">
+                        <h5>Climbing</h5>
+                        <!-- Climbing in Pool -->
+                        <div class="form-check form-switch">
+                            <input class="form-check-input barrier-switch" type="checkbox" role="switch" id="switchClimbing">
+                            <label class="form-check-label" for="switchClimbing">Disable This If You Have Climbing In Pool</label>
+                        </div>
                         <h5>Jungle Japes</h5>
                         <!-- Japes Coconut Gates -->
                         <div class="form-check form-switch">
@@ -312,7 +318,8 @@
 
             class Moves {
                 static Moveless = new Moves("Nothing", false);
-                static Slam = new Moves("Level Slam");
+                static LevelSlam = new Moves("Level Slam");
+                static Slam = new Moves("Green Slam");
                 // Kongs
                 static Diddy = new Moves("Diddy");
                 static Enguarde = new Moves("Enguarde");
@@ -336,6 +343,7 @@
                 static Diving = new Moves("Diving");
                 static Vines = new Moves("Vines");
                 static Barrels = new Moves("Barrels");
+                static Climbing = new Moves("Climbing");
                 // Guns
                 static Coconut = new Moves("Coconut");
                 static Peanut = new Moves("Peanut");
@@ -352,6 +360,7 @@
                 
                 static W3Bonus = new Moves("Caves Warp 3 Bonus");
                 static AnyGun = new Moves("Any Gun");
+                static ClimbInPool = new Moves("Climbing In Pool", true, [Moves.Climbing], true);
                 // Barriers
                 static JapesCoconut = new Moves("Japes Coconut Gates", true, [], true); // No logic determined yet for this
                 static JapesShellhive = new Moves("Japes Shellhive Gate", true, [Moves.Feather], true);
@@ -359,10 +368,10 @@
                 static Aztec5DT = new Moves("Aztec 5DT Switches", true, [Moves.Rocket, Moves.Peanut], true);
                 static AztecLlama = new Moves("Aztec Llama Switch", true, [Moves.Blast], true);
                 static FactoryProduction = new Moves("Production Room On", true, [Moves.Grab, Moves.Coconut], true);
-                static FactoryTesting = new Moves("Testing Side Open", true, [], true); // No logic determined yet for this
+                static FactoryTesting = new Moves("Testing Side Open", true, [Moves.Slam], true);
                 static GalleonLighthouse = new Moves("Lighthouse Side Open", true, [Moves.Coconut], true);
                 static GalleonPeanut = new Moves("Shipwreck Side Open", true, [Moves.Peanut], true);
-                static GalleonShipSpawned = new Moves("Ship Spawned", true, [Moves.Slam, Moves.Grab], true);
+                static GalleonShipSpawned = new Moves("Ship Spawned", true, [Moves.LevelSlam, Moves.Grab], true);
                 static ForestGreenTunnelPineapple = new Moves("Green Tunnel Opened (Pineapple)", true, [Moves.Pineapple], true);
                 static ForestGreenTunnelFeather = new Moves("Green Tunnel Opened (Feather)", true, [Moves.Feather], true);
                 static ForestYellowTunnel = new Moves("Yellow Tunnel Opened", true, [Moves.Grape], true);
@@ -371,7 +380,7 @@
                 static Day = new Moves("Fungi Day", true, [Moves.AnyGun], true);
                 static RaisedWater = new Moves("Galleon Raised Water", true, [Moves.GalleonLighthouse, Moves.Diving], true);
                 static LoweredWater = new Moves("Galleon Lowered Water", true, [Moves.GalleonLighthouse, Moves.Diving], true);
-                static TinyTempleIce = new Moves("Tiny Temple Ice Melted", true, [Moves.Guitar, Moves.Slam, Moves.Peanut], true);
+                static TinyTempleIce = new Moves("Tiny Temple Ice Melted", true, [Moves.Guitar, Moves.LevelSlam, Moves.Peanut], true);
                 static GalleonTreasure = new Moves("Treasure Room Open", true, [Moves.Enguarde, Moves.RaisedWater], true);
                 static CavesIceWalls = new Moves("Caves Ice Walls", true, [Moves.Punch], true);
                 // Crypt Entry
@@ -380,6 +389,7 @@
                 static CryptLankyEntry = new Moves("Castle Crypt Doors", true, [Moves.Grape], true);
                 static CryptTinyEntry = new Moves("Castle Crypt Doors", true, [Moves.Feather], true);
                 static CryptChunkyEntry = new Moves("Castle Crypt Doors", true, [Moves.Pineapple], true);
+                
 
                 constructor (name, requires_moves=true, barrier_moves=[], is_barrier=false) {
                     this.name = name;
@@ -433,6 +443,7 @@
 
             class Preset {
                 static Season2 = new Preset("Season 2", "s2", [
+                    "switchClimbing",
                     "switchAztec5DT",
                     "switchAztecLlama",
                     "switchFactoryProd",
@@ -442,6 +453,7 @@
                     "switchAztecIce",
                 ], 40, "Low", "Day");
                 static Beginner = new Preset("Beginner", "beginner", [
+                    "switchClimbing",
                     "switchAztec5DT",
                     "switchAztecLlama",
                     "switchFactoryProd",
@@ -451,6 +463,7 @@
                     "switchAztecIce",
                 ], 30, "Low", "Day");
                 static BLZR = new Preset("Balanced LZR", "blzr", [
+                    "switchClimbing",
                     "switchAztec5DT",
                     "switchFactoryProd",
                     "switchGalleonShipyard",
@@ -459,12 +472,14 @@
                     "switchAztecIce",
                 ], 40, "Low", "Dusk");
                 static TreasureHurry = new Preset("Treasure Hurry", "thurry", [
+                    "switchClimbing",
                     "switchAztecLlama",
                     "switchGalleonShipyard",
                     "switchGalleonSeasick",
                     "switchAztecIce",
                 ], 50, "Low", "Day");
                 static Season3Candidates = new Preset("Season 3 Candidates (Excl. CLO)", "s3can", [
+                    "switchClimbing",
                     "switchJapesCoconut",
                     "switchAztec5DT",
                     "switchAztecTunnel",
@@ -476,6 +491,7 @@
                     "switchAztecIce",
                 ], 40, "High", "Dusk");
                 static Season3CLO = new Preset("Season 3 CLO Candidate", "s3clo", [
+                    "switchClimbing",
                     "switchJapesCoconut",
                     "switchAztec5DT",
                     "switchAztecTunnel",
@@ -490,6 +506,7 @@
                 static Vanilla = new Preset("Vanilla", "vanilla", [], 75, "Low", "Day");
                 static Hell = new Preset("Hell Mode", "hell", [], 80, "Low", "Progressive");
                 static Season3 = new Preset("Season 3", "s3", [
+                    "switchClimbing",
                     "switchJapesCoconut",
                     "switchAztec5DT",
                     "switchAztecTunnel",
@@ -500,6 +517,18 @@
                     "switchCavesIgloo",
                     "switchAztecIce",
                 ], 45, "High", "Day");
+                static KEVIN = new Preset("KEVIN", "kevin", [
+                    "switchJapesCoconut",
+                    "switchAztecIce",
+                    "switchAztecTunnel",
+                    "switchAztec5DT",
+                    "switchFactoryProd",
+                    "switchFactoryTesting",
+                    "switchGalleonLighthouse",
+                    "switchGalleonShipyard",
+                    "switchGalleonSeasick",
+                    "switchCavesIgloo",
+                ], 40, "High", "Dusk");
 
                 constructor (name, key, barriers, cb_requirement, galleon_water, fungi_time) {
                     this.name = name;
@@ -521,6 +550,7 @@
                 Preset.Vanilla,
                 Preset.TreasureHurry,
                 Preset.Hell,
+                Preset.KEVIN,
             ]
 
             // Function to set a cookie
@@ -553,7 +583,7 @@
             let custom_presets = [{
                 "key": "custom0",
                 "name": "Season 2 (Obsolete)",
-                "setstr": '14738|00|40'
+                "setstr": '32739|00|40'
             }];
 
             function updateCookie() {
@@ -775,6 +805,7 @@
 
             function updateBarriers() {
                 barrier_data = {
+                    "switchClimbing": [Moves.ClimbInPool],
                     "switchJapesCoconut": [Moves.JapesCoconut],
                     "switchJapesShellhive": [Moves.JapesShellhive],
                     "switchAztecTunnel": [Moves.AztecTunnelDoor],
@@ -796,14 +827,14 @@
                     "switchGalleonTreasure": [Moves.GalleonTreasure],
                     "switchCavesWalls": [Moves.CavesIceWalls],
                     "switchCryptDoors": [Moves.CryptDKEntry, Moves.CryptDiddyEntry, Moves.CryptLankyEntry, Moves.CryptTinyEntry, Moves.CryptChunkyEntry],
-                }
+                };
                 opened_barriers = []
                 Object.keys(barrier_data).forEach(id => {
                     const doc = document.getElementById(id);
                     if (doc.checked) {
                         opened_barriers = opened_barriers.concat(barrier_data[id]);
                     }
-                })
+                });
             }
             updateBarriers()
 
@@ -826,26 +857,32 @@
             }
 
             const llama_temple_guns = [Moves.Coconut, Moves.Grape, Moves.Feather];
-            const llama_lava_moves = [Moves.Twirl, Moves.Slam];
-            const mush_top_access = [Moves.Rocket, Moves.Orangstand]
+            const llama_lava_moves = [Moves.Twirl, Moves.LevelSlam];
+            const mush_top_access = [Moves.Rocket, Moves.Orangstand];
+            //const diddy_aztec_tree = [[Moves.Rocket, Moves.ClimbInPool]];
+            //const mush_climb = [[Moves.ClimbInPool, Moves.Rocket]];
 
             const requirement_data = {
                 "Japes": {
                     "DK": [
-                        new Requirement(40, [[Moves.Moveless]]),
-                        new Requirement(40, [[Moves.Coconut]]),
-                        new Requirement(10, [[Moves.Vines]]),
-                        new Requirement(10, [[Moves.Vines, Moves.Blast]]),
+                        new Requirement(15, [[Moves.Moveless]]),
+                        new Requirement(10, [[Moves.Coconut, Moves.ClimbInPool]]),
+                        new Requirement(16, [[Moves.ClimbInPool]]),
+                        new Requirement(39, [[Moves.Coconut]]),
+                        new Requirement(10, [[Moves.Vines, Moves.ClimbInPool]]),
+                        new Requirement(10, [[Moves.Vines, Moves.ClimbInPool, Moves.Blast]]),
                     ],
                     "Diddy": [
-                        new Requirement(35, [[Moves.Moveless]]),
+                        new Requirement(5, [[Moves.Moveless]]),
                         new Requirement(10, [[Moves.Diving]]),
-                        new Requirement(30, [[Moves.Peanut]]),
-                        new Requirement(20, [[Moves.Peanut, Moves.Slam]]),
-                        new Requirement(5, [[Moves.Coconut]]),
+                        new Requirement(27, [[Moves.ClimbInPool]]),
+                        new Requirement(30, [[Moves.Peanut, Moves.ClimbInPool]]),
+                        new Requirement(20, [[Moves.Peanut, Moves.LevelSlam, Moves.ClimbInPool]]),
+                        new Requirement(8, [[Moves.Coconut]]),
                     ],
                     "Lanky": [
-                        new Requirement(19, [[Moves.Moveless]]),
+                        new Requirement(4, [[Moves.Moveless]]),
+                        new Requirement(15, [[Moves.ClimbInPool]]),
                         new Requirement(20, [[Moves.Grape]]),
                         new Requirement(10, [[Moves.Coconut]]),
                         new Requirement(11, [[Moves.Orangstand]]),
@@ -855,7 +892,8 @@
                         new Requirement(5, [[Moves.Peanut, Moves.Grape]]),
                     ],
                     "Tiny": [
-                        new Requirement(10, [[Moves.Moveless]]),
+                        new Requirement(5, [[Moves.Moveless]]),
+                        new Requirement(5, [[Moves.ClimbInPool]]),
                         new Requirement(12, [[Moves.Coconut]]),
                         new Requirement(10, [[Moves.Coconut, Moves.Feather]]),
                         new Requirement(10, [[Moves.Feather]]),
@@ -865,18 +903,20 @@
                         new Requirement(5, [[Moves.Peanut, Moves.Feather]]),
                     ],
                     "Chunky": [
-                        new Requirement(30, [[Moves.Moveless]]),
+                        new Requirement(15, [[Moves.Moveless]]),
+                        new Requirement(15, [[Moves.ClimbInPool]]),
                         new Requirement(30, [[Moves.Coconut, Moves.Pineapple]]),
                         new Requirement(5, [[Moves.Coconut, Moves.Barrels]]),
-                        new Requirement(20, [[Moves.JapesShellhive, Moves.Hunky]]),
+                        new Requirement(20, [[Moves.JapesShellhive, Moves.Hunky, Moves.ClimbInPool]]),
                         new Requirement(15, [[Moves.Barrels]]),
                     ]
                 },
                 "Aztec": {
                     "DK": [
-                        new Requirement(18, [[Moves.Moveless]]),
+                        new Requirement(3, [[Moves.Moveless]]),
+                        new Requirement(15, [[Moves.ClimbInPool]]),
                         new Requirement(30, [[Moves.Coconut, Moves.AztecTunnelDoor]]),
-                        new Requirement(20, llama_temple_guns.map(item => [Moves.AztecTunnelDoor, Moves.Slam, Moves.Strong, Moves.AztecLlama].concat([item]))),
+                        new Requirement(20, llama_temple_guns.map(item => [Moves.AztecTunnelDoor, Moves.LevelSlam, Moves.Strong, Moves.AztecLlama].concat([item]))),
                         new Requirement(15, llama_temple_guns.map(item => [Moves.AztecTunnelDoor, Moves.AztecLlama].concat([item]))),
                         new Requirement(7, [[Moves.AztecTunnelDoor]]),
                         new Requirement(10, [[Moves.Strong, Moves.Coconut]]),
@@ -884,23 +924,26 @@
                     "Diddy": [
                         new Requirement(5, [[Moves.Moveless]]),
                         new Requirement(10, [[Moves.Peanut]]),
-                        new Requirement(18, [[Moves.Peanut, Moves.Slam]]),
+                        new Requirement(18, [[Moves.Peanut, Moves.LevelSlam]]),
                         new Requirement(7, [[Moves.Peanut, Moves.Diving, Moves.TinyTempleIce]]),
-                        new Requirement(30, [[Moves.AztecTunnelDoor]]),
+                        new Requirement(15, [[Moves.AztecTunnelDoor]]),
+                        new Requirement(15, [[Moves.ClimbInPool]]), // Either or with Climb/Rocket
                         new Requirement(10, [[Moves.AztecTunnelDoor, Moves.Rocket]]),
                         new Requirement(10, [[Moves.AztecTunnelDoor, Moves.Peanut, Moves.Aztec5DT]]),
-                        new Requirement(10, [[Moves.AztecTunnelDoor, Moves.AztecLlama, Moves.Coconut, Moves.Slam, Moves.Strong, Moves.Peanut]]),
+                        new Requirement(10, [[Moves.AztecTunnelDoor, Moves.AztecLlama, Moves.Coconut, Moves.LevelSlam, Moves.Strong, Moves.Peanut]]),
                     ],
                     "Lanky": [
                         new Requirement(5, [[Moves.Moveless]]),
-                        new Requirement(35, [[Moves.AztecTunnelDoor]]),
+                        new Requirement(10, [[Moves.AztecTunnelDoor]]),
+                        new Requirement(25, [[Moves.AztecTunnelDoor, Moves.ClimbInPool]]),
                         new Requirement(10, [[Moves.AztecTunnelDoor, Moves.Aztec5DT, Moves.Grape]]),
                         new Requirement(25, [[Moves.AztecTunnelDoor, Moves.AztecLlama, Moves.Grape]]),
                         new Requirement(14, [[Moves.Grape, Moves.Diving, Moves.TinyTempleIce]]),
                         new Requirement(11, llama_temple_guns.map(item => [Moves.AztecTunnelDoor, Moves.AztecLlama].concat([item]))),
                     ],
                     "Tiny": [
-                        new Requirement(50, [[Moves.AztecTunnelDoor]]),
+                        new Requirement(25, [[Moves.AztecTunnelDoor]]),
+                        new Requirement(25, [[Moves.ClimbInPool]]), // I wish I knew how to make this an either/or for Climb or Twirl
                         new Requirement(5, [[Moves.Feather, Moves.Mini, Moves.Diving, Moves.TinyTempleIce]]),
                         new Requirement(20, [[Moves.Feather, Moves.Diving, Moves.TinyTempleIce]]),
                         new Requirement(3, llama_temple_guns.map(item => [Moves.AztecTunnelDoor, Moves.AztecLlama].concat([item]))),
@@ -920,40 +963,49 @@
                 },
                 "Factory": {
                     "DK": [
-                        new Requirement(20, [[Moves.Moveless]]),
+                        new Requirement(15, [[Moves.Moveless]]),
+                        new Requirement(5, [[Moves.ClimbInPool]]),
                         new Requirement(20, [[Moves.Blast]]),
                         new Requirement(15, [[Moves.Strong, Moves.FactoryProduction]]),
-                        new Requirement(45, [[Moves.Coconut]]),
+                        new Requirement(35, [[Moves.Coconut, Moves.FactoryTesting, Moves.ClimbInPool]]),
+                        new Requirement(10, [[Moves.Coconut]]),
                     ],
                     "Diddy": [
-                        new Requirement(35, [[Moves.Moveless]]),
-                        new Requirement(15, [[Moves.FactoryProduction]]),
-                        new Requirement(20, [[Moves.Spring]]),
-                        new Requirement(30, [[Moves.Guitar, Moves.Peanut]]),
+                        new Requirement(12, [[Moves.Moveless]]),
+                        new Requirement(8, [[Moves.FactoryTesting, Moves.ClimbInPool]]),
+                        new Requirement(10, [[Moves.ClimbInPool]]),
+                        new Requirement(15, [[Moves.FactoryProduction, Moves.ClimbInPool]]),
+                        new Requirement(25, [[Moves.Spring, Moves.ClimbInPool, Moves.FactoryTesting]]),
+                        new Requirement(30, [[Moves.Guitar, Moves.Peanut, Moves.FactoryTesting, Moves.ClimbInPool]]),
                     ],
                     "Lanky": [
-                        new Requirement(27, [[Moves.Moveless]]),
-                        new Requirement(20, [[Moves.FactoryProduction]]),
-                        new Requirement(20, [[Moves.Orangstand, Moves.FactoryProduction]]),
-                        new Requirement(3, [[Moves.Orangstand]]),
-                        new Requirement(20, [[Moves.Grape, Moves.FactoryProduction]]),
-                        new Requirement(10, [[Moves.Trombone, Moves.Grape]]),
+                        new Requirement(10, [[Moves.Moveless]]),
+                        new Requirement(20, [[Moves.FactoryProduction, Moves.ClimbInPool]]),
+                        new Requirement(20, [[Moves.Orangstand, Moves.FactoryProduction, Moves.ClimbInPool]]),
+                        new Requirement(5, [[Moves.Orangstand]]),
+                        new Requirement(15, [[Moves.FactoryTesting, Moves.ClimbInPool]]),
+                        new Requirement(20, [[Moves.Grape, Moves.FactoryProduction, Moves.ClimbInPool]]),
+                        new Requirement(10, [[Moves.FactoryTesting, Moves.ClimbInPool, Moves.Trombone, Moves.Grape]]),
                     ],
                     "Tiny": [
-                        new Requirement(40, [[Moves.Moveless]]),
-                        new Requirement(20, [[Moves.FactoryProduction]]),
-                        new Requirement(5, [[Moves.Twirl, Moves.FactoryProduction]]),
-                        new Requirement(5, [[Moves.Mini]]),
-                        new Requirement(20, [[Moves.Feather]]),
+                        new Requirement(10, [[Moves.Moveless]]), // 2 Bunches on Mid Hatch, Maybe Move to Climb?
+                        new Requirement(5, [[Moves.ClimbInPool]]),
+                        new Requirement(25, [[Moves.FactoryTesting, Moves.ClimbInPool]]),
+                        new Requirement(20, [[Moves.FactoryProduction, Moves.ClimbInPool]]),
+                        new Requirement(5, [[Moves.Twirl, Moves.FactoryProduction, Moves.ClimbInPool]]),
+                        new Requirement(5, [[Moves.Mini, Moves.FactoryTesting, Moves.ClimbInPool]]),
+                        new Requirement(20, [[Moves.FactoryTesting, Moves.Feather, Moves.ClimbInPool]]),
                         new Requirement(10, [[Moves.Feather, Moves.FactoryProduction]]),
                     ],
                     "Chunky": [
-                        new Requirement(25, [[Moves.Moveless]]),
-                        new Requirement(20, [[Moves.FactoryProduction]]),
+                        new Requirement(20, [[Moves.Moveless]]), // Same as Factory Tiny's Moveless
+                        new Requirement(5, [[Moves.ClimbInPool, Moves.FactoryTesting]]),
+                        new Requirement(20, [[Moves.FactoryProduction, Moves.ClimbInPool]]),
                         new Requirement(15, [[Moves.Punch]]),
-                        new Requirement(20, [[Moves.Pineapple]]),
-                        new Requirement(10, [[Moves.Punch, Moves.Triangle]]),
-                        new Requirement(10, [[Moves.Punch, Moves.Triangle, Moves.Pineapple]]),
+                        new Requirement(10, [[Moves.Pineapple]]),
+                        new Requirement(10, [[Moves.Pineapple, Moves.FactoryTesting, Moves.ClimbInPool]]),
+                        new Requirement(10, [[Moves.Punch, Moves.Triangle, Moves.FactoryTesting, Moves.ClimbInPool]]),
+                        new Requirement(10, [[Moves.Punch, Moves.Triangle, Moves.Pineapple, Moves.FactoryTesting, Moves.ClimbInPool]]),
                     ],
                 },
                 "Galleon": {
@@ -964,8 +1016,8 @@
                         new Requirement(10, [[Moves.Coconut]]),
                         new Requirement(15, [[Moves.Diving, Moves.GalleonPeanut]]),
                         new Requirement(10, [[Moves.Diving, Moves.Bongos, Moves.GalleonPeanut]]),
-                        new Requirement(20, [[Moves.GalleonLighthouse, Moves.RaisedWater, Moves.Slam]]),
-                        new Requirement(10, [[Moves.GalleonLighthouse, Moves.RaisedWater, Moves.Slam, Moves.Coconut]]),
+                        new Requirement(20, [[Moves.GalleonLighthouse, Moves.RaisedWater, Moves.LevelSlam, Moves.ClimbInPool]]),
+                        new Requirement(10, [[Moves.GalleonLighthouse, Moves.RaisedWater, Moves.LevelSlam, Moves.Coconut, Moves.ClimbInPool]]),
                     ],
                     "Diddy": [
                         new Requirement(10, [[Moves.Moveless]]),
@@ -982,7 +1034,7 @@
                         new Requirement(25, [[Moves.GalleonLighthouse, Moves.Diving]]),
                         new Requirement(1, [[Moves.GalleonLighthouse, Moves.GalleonTreasure, Moves.RaisedWater, Moves.Diving, Moves.GalleonPeanut]]),
                         new Requirement(5, [[Moves.Diving, Moves.GalleonPeanut]]),
-                        new Requirement(10, [[Moves.Diving, Moves.Slam, Moves.GalleonPeanut]]),
+                        new Requirement(10, [[Moves.Diving, Moves.LevelSlam, Moves.GalleonPeanut]]),
                         new Requirement(10, [[Moves.Grape, Moves.GalleonPeanut]]),
                         new Requirement(15, [[Moves.Diving, Moves.Trombone, Moves.LoweredWater, Moves.GalleonPeanut]]),
                         new Requirement(4, [[Moves.GalleonLighthouse, Moves.Diving, Moves.RaisedWater, Moves.GalleonTreasure, Moves.Balloon, Moves.GalleonPeanut]]),
@@ -990,7 +1042,7 @@
                     ],
                     "Tiny": [
                         new Requirement(9, [[Moves.Moveless]]),
-                        new Requirement(10, [[Moves.Slam, Moves.Diving, Moves.GalleonPeanut]]),
+                        new Requirement(10, [[Moves.LevelSlam, Moves.Diving, Moves.GalleonPeanut]]),
                         new Requirement(8, [[Moves.Vines]]),
                         new Requirement(5, [[Moves.GalleonLighthouse, Moves.RaisedWater]]),
                         new Requirement(10, [[Moves.GalleonLighthouse, Moves.Feather, Moves.LoweredWater]]),
@@ -1014,29 +1066,36 @@
                 },
                 "Fungi": {
                     "DK": [
-                        new Requirement(40, [[Moves.Moveless]]),
-                        new Requirement(10, [[Moves.Coconut, Moves.Slam]]),
-                        new Requirement(5, [[Moves.Night]]),
-                        new Requirement(10, [[Moves.Night, Moves.Strong]]),
-                        new Requirement(10, [[Moves.Blast]]),
-                        new Requirement(15, [[Moves.Coconut, Moves.Peanut, Moves.Grape, Moves.Feather, Moves.Pineapple]]),
-                        new Requirement(10, [[Moves.Coconut]]),
+                        new Requirement(28, [[Moves.Moveless]]), // Kick Jump to Mid Mush Exterior to get the middle (13?) + 1 on Bottom Part of Ladder CBs 
+                        new Requirement(2, [[Moves.ClimbInPool]]), // 2 on the Blast Pad Ladder
+                        new Requirement(15, [[Moves.Coconut, Moves.Peanut, Moves.Grape, Moves.Feather, Moves.Pineapple, Moves.LevelSlam]]), //CoL
+                        new Requirement(10, [[Moves.Blast, Moves.ClimbInPool]]),
+                        new Requirement(5, [[Moves.ClimbInPool]]), // W5 Upper
+                        new Requirement(10, [[Moves.Coconut]]), // Behind Dark Barn
+                        new Requirement(5, [[Moves.Slam, Moves.Day]]), // Inside Mill Box
+                        new Requirement(10, [[Moves.Coconut, Moves.LevelSlam]]), // Inside Mill Grab Box
+                        new Requirement(5, [[Moves.Night]]), // Thornvine Path
+                        new Requirement(5, [[Moves.Night, Moves.Strong]]), // Thornvine Switch
+                        new Requirement(5, [[Moves.Night, Moves.Strong, Moves.Slam]]), // Inside Thornvine Box
                     ],
                     "Diddy": [
-                        new Requirement(45, [[Moves.Moveless]]),
+                        new Requirement(28, [[Moves.Moveless]]),
+                        new Requirement(17, [[Moves.ClimbInPool]]),
                         new Requirement(15, [[Moves.ForestYellowTunnel]]),
                         new Requirement(5, [[Moves.ForestYellowTunnel, Moves.Rocket]]),
                         new Requirement(10, [[Moves.Peanut, Moves.Day]]),
-                        new Requirement(10, [[Moves.Peanut, Moves.Slam]]),
+                        new Requirement(10, [[Moves.Peanut, Moves.LevelSlam, Moves.ClimbInPool]]),
                         new Requirement(5, [[Moves.Spring]]),
                         new Requirement(10, [[Moves.Night, Moves.Spring, Moves.Guitar]]),
                     ],
                     "Lanky": [
-                        new Requirement(32, [[Moves.Moveless]]),
-                        new Requirement(20, [[Moves.Grape]]),
+                        new Requirement(21, [[Moves.Moveless]]),
+                        new Requirement(11, [[Moves.ClimbInPool]]), // Either or with Climb/Balloon
+                        new Requirement(10, [[Moves.Grape]]),
+                        new Requirement(10, [[Moves.Grape, Moves.ClimbInPool]]),
                         new Requirement(18, [[Moves.ForestYellowTunnel]]),
-                        new Requirement(5, [[Moves.Orangstand]]),
-                        new Requirement(15, [[Moves.Slam, Moves.Orangstand]]),
+                        new Requirement(5, [[Moves.Orangstand, Moves.ClimbInPool]]),
+                        new Requirement(15, [[Moves.LevelSlam, Moves.Orangstand, Moves.ClimbInPool]]),
                         new Requirement(10, [[Moves.Night]]),
                         ],
                     "Tiny": [
@@ -1048,18 +1107,20 @@
                         new Requirement(10, [[Moves.Feather]]), // + Fungi Night, but assumed with the req for feather
                         new Requirement(10, [[Moves.Feather]]),
                         new Requirement(4, [[Moves.ForestGreenTunnelFeather]]),
-                        new Requirement(16, [[Moves.ForestGreenTunnelFeather, Moves.ForestGreenTunnelPineapple]]),
+                        new Requirement(1, [[Moves.ForestGreenTunnelFeather, Moves.ForestGreenTunnelPineapple]]),
+                        new Requirement(15, [[Moves.ForestGreenTunnelFeather, Moves.ForestGreenTunnelPineapple, Moves.ClimbInPool]]), // Top of Mush Trees
                         new Requirement(8, [[Moves.ForestYellowTunnel]]),
                         new Requirement(5, [[Moves.ForestYellowTunnel, Moves.Mini, Moves.Sax]]),
                     ],
                     "Chunky": [
-                        new Requirement(51, [[Moves.Moveless]]),
+                        new Requirement(11, [[Moves.Moveless]]),
+                        new Requirement(40, [[Moves.ClimbInPool]]),
                         new Requirement(5, [[Moves.Punch, Moves.Day]]),
                         new Requirement(14, [[Moves.ForestGreenTunnelFeather, Moves.ForestGreenTunnelPineapple]]),
-                        new Requirement(5, [[Moves.Vines], [Moves.Night]]),
-                        new Requirement(5, [[Moves.Slam]]),
-                        new Requirement(10, [[Moves.Slam, Moves.Pineapple]]),
-                        new Requirement(10, [[Moves.Pineapple]]),
+                        new Requirement(5, [[Moves.Vines], [Moves.Night], [Moves.ClimbInPool]]), // Not 100% sure why the moves are in different brackets
+                        new Requirement(5, [[Moves.LevelSlam, Moves.ClimbInPool]]), // Either or with Rocket/Punch
+                        new Requirement(10, [[Moves.LevelSlam, Moves.Pineapple, Moves.ClimbInPool]]),
+                        new Requirement(10, [[Moves.Pineapple, Moves.ClimbInPool]]), // Night Door Kasplat Balloon, I believe?
                     ],
                 },
                 "Caves": {
@@ -1084,8 +1145,8 @@
                     ],
                     "Lanky": [
                         new Requirement(15, [[Moves.Moveless]]),
-                        new Requirement(10, [[Moves.Slam, Moves.Grape]]),
-                        new Requirement(5, [[Moves.Slam, Moves.Balloon]]),
+                        new Requirement(10, [[Moves.LevelSlam, Moves.Grape]]),
+                        new Requirement(5, [[Moves.LevelSlam, Moves.Balloon]]),
                         new Requirement(20, [[Moves.Rocket]]),
                         new Requirement(20, [[Moves.Balloon]]),
                         new Requirement(10, [[Moves.Grape]]),
@@ -1121,8 +1182,8 @@
                 "Castle": {
                     "DK": [
                         new Requirement(50, [[Moves.Moveless]]),
-                        new Requirement(10, [[Moves.Slam]]),
-                        new Requirement(10, [[Moves.Slam, Moves.Strong]]),
+                        new Requirement(10, [[Moves.LevelSlam]]),
+                        new Requirement(10, [[Moves.LevelSlam, Moves.Strong]]),
                         new Requirement(15, [[Moves.Blast, Moves.Coconut]]),
                         new Requirement(5, [[Moves.CryptDKEntry]]),
                         new Requirement(10, [[Moves.CryptDKEntry, Moves.Coconut]]),
@@ -1131,24 +1192,24 @@
                         new Requirement(5, [[Moves.CryptDiddyEntry]]),
                         new Requirement(20, [[Moves.Peanut]]),
                         new Requirement(10, [[Moves.Rocket]]),
-                        new Requirement(15, [[Moves.Slam, Moves.Rocket]]),
-                        new Requirement(20, [[Moves.Slam, Moves.Peanut]]),
+                        new Requirement(15, [[Moves.LevelSlam, Moves.Rocket]]),
+                        new Requirement(20, [[Moves.LevelSlam, Moves.Peanut]]),
                         new Requirement(20, [[Moves.Punch]]),
                         new Requirement(10, [[Moves.Charge, Moves.Peanut, Moves.CryptDiddyEntry]]),
                     ],
                     "Lanky": [
                         new Requirement(30, [[Moves.Moveless]]),
-                        new Requirement(30, [[Moves.Slam]]),
-                        new Requirement(20, [[Moves.Slam, Moves.Grape]]),
-                        new Requirement(10, [[Moves.Slam, Moves.Grape, Moves.Trombone, Moves.Balloon]]),
+                        new Requirement(30, [[Moves.LevelSlam]]),
+                        new Requirement(20, [[Moves.LevelSlam, Moves.Grape]]),
+                        new Requirement(10, [[Moves.LevelSlam, Moves.Grape, Moves.Trombone, Moves.Balloon]]),
                         new Requirement(10, [[Moves.Grape, Moves.Sprint]]),
                     ],
                     "Tiny": [
                         new Requirement(50, [[Moves.Moveless]]),
                         new Requirement(5, [[Moves.Mini]]),
-                        new Requirement(5, [[Moves.Diddy, Moves.Slam]]),
-                        new Requirement(15, [[Moves.Diddy, Moves.Slam, Moves.Monkeyport]]),
-                        new Requirement(10, [[Moves.Diddy, Moves.Slam, Moves.Monkeyport, Moves.Feather]]),
+                        new Requirement(5, [[Moves.Diddy, Moves.LevelSlam]]),
+                        new Requirement(15, [[Moves.Diddy, Moves.LevelSlam, Moves.Monkeyport]]),
+                        new Requirement(10, [[Moves.Diddy, Moves.LevelSlam, Moves.Monkeyport, Moves.Feather]]),
                         new Requirement(10, [[Moves.Feather]]),
                         new Requirement(5, [[Moves.CryptTinyEntry]]),
                     ],
@@ -1156,10 +1217,10 @@
                         new Requirement(30, [[Moves.Moveless]]),
                         new Requirement(10, [[Moves.Punch, Moves.CryptChunkyEntry]]),
                         new Requirement(30, [[Moves.Punch, Moves.Pineapple]]),
-                        new Requirement(5, [[Moves.Slam, Moves.Barrels, Moves.Punch]]),
+                        new Requirement(5, [[Moves.LevelSlam, Moves.Barrels, Moves.Punch]]),
                         new Requirement(5, [[Moves.Blast]]),
                         new Requirement(10, [[Moves.Blast, Moves.Punch, Moves.Pineapple]]),
-                        new Requirement(10, [[Moves.Slam, Moves.Pineapple]]),
+                        new Requirement(10, [[Moves.LevelSlam, Moves.Pineapple]]),
                     ],
                 },
             }


### PR DESCRIPTION
Adds Climbing into the CB Calculator
- There are some either/or stuff that I'm not sure how to implement like the Aztec 5DT trees which logically require climbing, but Im sure twirl will be in logic someday, and the Mushroom climb requiring either Climbing or Rocket to reach the top
- Climbing Only shows up when the selector for it is disabled because I set it up as a barrier. Which also means I added climbing to every preset except Kevin
- Added Kevin preset
- Feel free to take a second look at the level requirements, but im pretty sure everything is right except for the either or stuff which I just made it as a climbing req
- Changed Moves.Slam to Moves.LevelSlam and added a Moves.Slam which is just a green slam