### PR TITLE
Update cb_calculator.html

### DIFF
--- a/cb_calculator.html
+++ b/cb_calculator.html
@@ -1096,7 +1096,7 @@
                         new Requirement(10, [[Moves.Coconut, Moves.LevelSlam]]), // Inside Mill Grab Box
                         new Requirement(5, [[Moves.Night]]), // Thornvine Path
                         new Requirement(5, [[Moves.Night, Moves.Strong]]), // Thornvine Switch
-                        new Requirement(5, [[Moves.Night, Moves.Strong, Moves.Slam]]), // Inside Thornvine Box
+                        new Requirement(5, [[Moves.Night, Moves.Strong, Moves.LevelSlam]]), // Inside Thornvine Box
                     ],
                     "Diddy": [
                         new Requirement(28, [[Moves.Moveless]]),


### PR DESCRIPTION
Only needs green slam once you're inside, but you still need level slam to get inside in the first place. Unless we somehow plan to accommodate LZR in this calc, this should be fine. Keeping green slam in the line as well would I assume be fine but redundant