### PR TITLE
Restore fringe logic requirements cb_calculator.html

### DIFF
--- a/cb_calculator.html
+++ b/cb_calculator.html
@@ -320,6 +320,7 @@
                 static LevelSlam = new Moves("Level Slam");
                 static Slam = new Moves("Green Slam");
                 // Kongs
+                static Diddy = new Moves("Diddy");
                 static Enguarde = new Moves("Enguarde");
                 // Special Moves
                 static Strong = new Moves("Strong Kong");
@@ -356,7 +357,7 @@
                 static Sax = new Moves("Sax");
                 static Triangle = new Moves("Triangle");
                 // Misc Events
-                
+                static W3Bonus = new Moves("Caves Warp 3 Bonus");
                 static AnyGun = new Moves("Any Gun");
                 static FreeDiddyGun = new Moves("Free Diddy Gun");
                 static CheckOfLegends = new Moves("All 5 Guns");


### PR DESCRIPTION
Restored the Diddy move for use in Ballroom access, and restored the Caves Warp 3 move for use in Mini Bonus Cave access