### PR TITLE
Fix silent crashes where certain moves are accessed while undefined

### DIFF
--- a/cb_calculator.html
+++ b/cb_calculator.html
@@ -402,6 +402,8 @@
                 static CryptChunkyEntry = new Moves("Castle Crypt Doors", true, [Moves.Pineapple], true);
                 // Enable all warps
                 static AllWarps = new Moves("Preactivate All Warps");
+                static IsDiddy = new Moves("Diddy");
+                static IsTiny = new Moves("Tiny");
 
 
                 constructor (name, requires_moves=true, barrier_moves=[], is_barrier=false) {
@@ -1122,6 +1124,13 @@
                         group.forEach(move_set => {
                             if (move_set == Moves.AllWarps) {
                                 // All Warps is off; this branch is unsatisfiable.
+                            } else if (move_set == Moves.IsDiddy || move_set == Moves.IsTiny) {
+                                // Since the Kong whose medal we're collecting is already assumed, these flags only represent using 
+                                // Diddy and Tiny's backlip to reach an area for another Kong. Currently this would only be used for 
+                                // Factory DK medal when climbing is shuffled, since you can skip the R&D ladders with the flippers
+                                // in order to reach the CBs in the power hut with DK.
+                                // But since there is no tag barrel between the R&D ladders and the Power Hut, this would break the 
+                                // Tag Anywhere assumption and is not actually in logic. So we can safely filter these out of the move list.
                             } else if (move_set.requires_moves) {
                                 if (!all_moves.includes(move_set)) {
                                     all_moves.push(move_set);

--- a/cb_calculator.html
+++ b/cb_calculator.html
@@ -369,6 +369,9 @@
                 static FreeDiddyGun = new Moves("Free Diddy Gun");
                 static CheckOfLegends = new Moves("All 5 Guns");
 
+                // Climbing
+                static ClimbingCheck = new Moves("Climbing", true, [Moves.Climbing], true); // Had to move this above the Barriers since JapesCoconut requires climbing
+
                 // Barriers
                 static JapesCoconut = new Moves("Japes Coconut Gates", true, [Moves.FreeDiddyGun, Moves.ClimbingCheck], true); // No logic determined yet for this
                 static JapesShellhive = new Moves("Japes Shellhive Gate", true, [Moves.Feather], true);
@@ -397,8 +400,6 @@
                 static CryptLankyEntry = new Moves("Castle Crypt Doors", true, [Moves.Grape], true);
                 static CryptTinyEntry = new Moves("Castle Crypt Doors", true, [Moves.Feather], true);
                 static CryptChunkyEntry = new Moves("Castle Crypt Doors", true, [Moves.Pineapple], true);
-                // Climbing
-                static ClimbingCheck = new Moves("Climbing", true, [Moves.Climbing], true);
                 // Enable all warps
                 static AllWarps = new Moves("Preactivate All Warps");
 


### PR DESCRIPTION
Fixed two cases where moves were being accessed while undefined and causing the Required Moves list not to update:
1. Any Preset with climbing shuffled and the Japes coconut gates closed would crash when trying to calculate any Kong's Japes medal.
2. Any Preset with climbing shuffled would crash when trying to calculate Factory DK medal. This was caused by the requirements data included flags for "IsDiddy" and "IsTiny" which were undefined in the calculator's code. I had to add these flags in so everything would render properly, but also these requirements  aren't actually in logic per Lrauq, so I ended up filtering out the two permutations that used them anyway.

Verification note:
Factory DK medal on the Rainbow Barrier preset should no longer crash on this branch. But to verify that the IsDiddy and IsTiny moves were filtered out properly you can set the Medal Requirement to 50, which will put the Power Hut CBs into logic. If this branch is working properly you should see an entry for Climbing + Coconut, and you should NOT see an entry for Coconut + Diddy, or Coconut + Tiny.